### PR TITLE
replace use of REST key with Client Key

### DIFF
--- a/Example/WCParsePushExample/WCParsePushExample/WCAppDelegate.m
+++ b/Example/WCParsePushExample/WCParsePushExample/WCAppDelegate.m
@@ -9,18 +9,25 @@
 #import "WCAppDelegate.h"
 #import "WCParsePushInstallation.h"
 
-#warning Fill in your Parse App Id and REST API Key
+#warning Fill in your Parse App Id and Client Key
 #define kParseApplicationId @"<YOUR-APP-ID>"
-#define kParseRestAPIKey @"<YOUR-REST-API_KEY>"
+#define kParseClientKey @"<YOUR-CLIENT-KEY>"
 
 @implementation WCAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Setup Push Notifications
-    [WCParsePushInstallation setApplicationId:kParseApplicationId restAPIKey:kParseRestAPIKey];
-    [[UIApplication sharedApplication] registerForRemoteNotificationTypes:(UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound)];
-    
+    [WCParsePushInstallation setApplicationId:kParseApplicationId clientKey:kParseClientKey];
+
+    if([[UIApplication sharedApplication] respondsToSelector:@selector(registerForRemoteNotificationTypes)]){
+        [[UIApplication sharedApplication] registerForRemoteNotificationTypes:(UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound)];
+    } else {
+        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes: (UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound) categories: nil];
+        [[UIApplication sharedApplication] registerUserNotificationSettings: settings];
+        [[UIApplication sharedApplication] registerForRemoteNotifications];
+    }
+
     return YES;
 }
 							

--- a/Example/WCParsePushExample/WCParsePushExample/WCParsePushExample-Info.plist
+++ b/Example/WCParsePushExample/WCParsePushExample/WCParsePushExample-Info.plist
@@ -36,5 +36,23 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>parse.com</key>
+            <dict>
+                <!--Include to allow subdomains-->
+                <key>NSIncludesSubdomains</key>
+                <true/>
+                <!--Include to allow HTTP requests-->
+                <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <!--Include to specify minimum TLS version-->
+                <key>NSTemporaryExceptionMinimumTLSVersion</key>
+                <string>TLSv1.1</string>
+            </dict>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Objective-C:
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Setup Push Notifications
-    [WCParsePushInstallation setApplicationId:@"<YOUR-APP-ID>" restAPIKey:@"<YOUR-REST-API_KEY>"];
+    [WCParsePushInstallation setApplicationId:@"<YOUR-APP-ID>" clientKey:@"<YOUR-CLIENT-KEY>"];
 
-  	UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound categories:nil];
-  	[application registerUserNotificationSettings:settings];
+    UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound categories:nil];
+    [application registerUserNotificationSettings:settings];
     [application registerForRemoteNotifications];
     
     return YES;
@@ -40,17 +40,41 @@ Objective-C:
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-    [[WCParsePushInstallation currentInstallation] setDeviceTokenFromData:deviceToken];    
+    [[WCParsePushInstallation currentInstallation] setDeviceTokenFromData:deviceToken];
 }
 ```
+
 Swift:
+
 ```swift
 func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
 
     // Setup Push Notifications
-    WCParsePushInstallation.setApplicationId("<YOUR-APP-ID>", restAPIKey: "<YOUR-REST-API_KEY>")
+    WCParsePushInstallation.setApplicationId("<YOUR-APP-ID>", clientKey: "<YOUR-CLIENT-KEY>")
 
 	let settings = UIUserNotificationSettings(forTypes: UIUserNotificationType.Alert | UIUserNotificationType.Badge | UIUserNotificationType.Sound, categories: nil)
+    application.registerUserNotificationSettings(settings)
+    application.registerForRemoteNotifications()
+    
+    return YES;
+}
+
+func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: NSData) {
+
+    let pushInstallation = WCParsePushInstallation.currentInstallation()
+    pushInstallation.setDeviceTokenFromData(deviceToken)
+}
+```
+
+Swift 2.0:
+
+```swift
+func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+
+    // Setup Push Notifications
+    WCParsePushInstallation.setApplicationId("<YOUR-APP-ID>", clientKey: "<YOUR-CLIENT-KEY>")
+
+	let settings = UIUserNotificationSettings(forTypes: [.Alert, .Badge, .Sound], categories: nil)
     application.registerUserNotificationSettings(settings)
     application.registerForRemoteNotifications()
     

--- a/WCParsePush/WCParsePushInstallation.h
+++ b/WCParsePush/WCParsePushInstallation.h
@@ -25,9 +25,9 @@ typedef void (^WCParsePushBooleanResultBlock)(BOOL succeeded, NSError *error);
 - (void)setDeviceTokenFromData:(NSData *)deviceTokenData;
 
 // Application Id and Client Key Methods
-+ (void)setApplicationId:(NSString *)applicationId restAPIKey:(NSString *)restAPIKey;
++ (void)setApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey;
 + (NSString *)getApplicationId;
-+ (NSString *)getRestAPIKey;
++ (NSString *)getClientKey;
 
 // Channel Methods
 - (BOOL)addChannel:(NSString *)channel;

--- a/WCParsePush/WCParsePushInstallation.m
+++ b/WCParsePush/WCParsePushInstallation.m
@@ -10,16 +10,16 @@
 #import "KSReachability.h"
 
 #define kParseHeaderApplicationId @"X-Parse-Application-Id"
-#define kParseHeaderRestApiKey @"X-Parse-REST-API-Key"
+#define kParseHeaderClientKey @"X-Parse-Client-Key"
 
-#define kParseRestAPIUrl @"https://api.parse.com/1/installations"
+#define kParseClientAPIUrl @"https://api.parse.com/1/classes/_Installation"
 
 NSString * const WCParsePushErrorDomain = @"WCParsePushErrorDomain";
 
 @interface WCParsePushInstallation ()
 
 @property (strong, nonatomic) NSString *applicationId;
-@property (strong, nonatomic) NSString *restAPIKey;
+@property (strong, nonatomic) NSString *clientKey;
 @property (strong, nonatomic) NSURLSession *urlSession;
 
 @property (strong, nonatomic) WCParsePushData *eventuallySaveData;
@@ -75,7 +75,7 @@ NSString * const WCParsePushErrorDomain = @"WCParsePushErrorDomain";
         NSMutableDictionary *headers = [NSMutableDictionary dictionaryWithCapacity:3];
         [headers setObject:@"application/json" forKey: @"Content-Type"];
         if(self.applicationId) [headers setObject:self.applicationId forKey:kParseHeaderApplicationId];
-        if(self.restAPIKey) [headers setObject:self.restAPIKey forKey:kParseHeaderRestApiKey];
+        if(self.clientKey) [headers setObject:self.clientKey forKey:kParseHeaderClientKey];
         
         [sessionConfiguration setHTTPAdditionalHeaders:headers];
         self.urlSession = [NSURLSession sessionWithConfiguration:sessionConfiguration];
@@ -147,17 +147,17 @@ NSString * const WCParsePushErrorDomain = @"WCParsePushErrorDomain";
 
 #pragma mark - Application Id and Client Key methods
 
-+ (void)setApplicationId:(NSString *)applicationId restAPIKey:(NSString *)restAPIKey
++ (void)setApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey
 {
     if([applicationId length] == 0) {
         [NSException raise:NSInvalidArgumentException format:@"Parse application id cannot be empty."];
     }
-    if([restAPIKey length] == 0) {
-        [NSException raise:NSInvalidArgumentException format:@"Parse REST API key cannot be empty."];
+    if([clientKey length] == 0) {
+        [NSException raise:NSInvalidArgumentException format:@"Parse Client key cannot be empty."];
     }
     WCParsePushInstallation *currentInstallation = [WCParsePushInstallation currentInstallation];
     [currentInstallation setApplicationId:applicationId];
-    [currentInstallation setRestAPIKey:restAPIKey];
+    [currentInstallation setClientKey:clientKey];
     
     // Invalidate the URL session
     [currentInstallation setUrlSession:nil];
@@ -168,9 +168,9 @@ NSString * const WCParsePushErrorDomain = @"WCParsePushErrorDomain";
     return [[WCParsePushInstallation currentInstallation] applicationId];
 }
 
-+ (NSString *)getRestAPIKey
++ (NSString *)getClientKey
 {
-    return [[WCParsePushInstallation currentInstallation] restAPIKey];
+    return [[WCParsePushInstallation currentInstallation] clientKey];
 }
 
 #pragma mark - Public Save Methods
@@ -312,11 +312,11 @@ NSString * const WCParsePushErrorDomain = @"WCParsePushErrorDomain";
     NSString *method;
     
     if(self.objectId) {
-        url = [NSURL URLWithString:[kParseRestAPIUrl stringByAppendingPathComponent:self.objectId]];
+        url = [NSURL URLWithString:[kParseClientAPIUrl stringByAppendingPathComponent:self.objectId]];
         method = @"PUT";
     }
     else {
-        url = [NSURL URLWithString:kParseRestAPIUrl];
+        url = [NSURL URLWithString:kParseClientAPIUrl];
         method = @"POST";
     }
     


### PR DESCRIPTION
By using the client endpoint it's now possible to use the client key instead of the REST key.

NB. Not thoroughly tested, although it works in my implementation. (only using push registration and receiving)
